### PR TITLE
Fix config to use flat ESLint recommended rules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,8 @@ module.exports = [
       jest: jestPlugin,
     },
     rules: {
-      ...tseslint.configs['eslint-recommended'].rules,
+      // use flat config recommended rules from @typescript-eslint
+      ...tseslint.configs['flat/eslint-recommended'].rules,
       ...tseslint.configs.recommended.rules,
       ...prettierPlugin.configs.recommended.rules,
       'prettier/prettier': 'error',

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,6 +1,5 @@
 const config = require('./index.js');
 const flatConfig = config.default || config;
-console.log('DEBUG imported config:', flatConfig);
 
 describe('@dendavidov/eslint-config (flat config)', () => {
   it('should export a flat config array', () => {
@@ -20,7 +19,7 @@ describe('@dendavidov/eslint-config (flat config)', () => {
     expect(main.rules).toHaveProperty('prettier/prettier', 'error');
     const ruleKeys = Object.keys(main.rules);
     expect(ruleKeys).toEqual(
-      expect.arrayContaining(['@typescript-eslint/ban-ts-comment', 'prettier/prettier']),
+      expect.arrayContaining(['@typescript-eslint/ban-ts-comment', 'prettier/prettier', 'no-var']),
     );
   });
 


### PR DESCRIPTION
## Summary
- use `flat/eslint-recommended` rules from `@typescript-eslint/eslint-plugin`
- clean up test debug output
- verify rule presence for `no-var`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687965e47b908332b6cc4a986f3e0b60