### PR TITLE
Add eslint-plugin-security

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Opinionated ESLint flat config for TypeScript-based Node.js projects.
 
 - **ESLint 9+ flat config**
 - **Node.js 22.x LTS or higher required**
-- **TypeScript, Prettier, and Jest support out of the box**
+- **TypeScript, Prettier, Jest, and Security rules out of the box**
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jest": "^29.0.1",
-        "eslint-plugin-prettier": "^5.5.1"
+        "eslint-plugin-prettier": "^5.5.1",
+        "eslint-plugin-security": "^3.0.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
@@ -26,6 +27,9 @@
         "husky": "^9.1.7",
         "jest": "^30.0.4",
         "prettier": "^3.6.2"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5560,6 +5564,21 @@
         "eslint-config-prettier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-security": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-3.0.1.tgz",
+      "integrity": "sha512-XjVGBhtDZJfyuhIxnQ/WMm385RbX3DBu7H1J7HNNhmB2tnGxMeqVSnYv79oAj992ayvIBZghsymwkYFS6cGH4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-regex": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-scope": {
@@ -13152,6 +13171,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -13323,6 +13351,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
       }
     },
     "node_modules/safe-regex-test": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jest": "^29.0.1",
-    "eslint-plugin-prettier": "^5.5.1"
+    "eslint-plugin-prettier": "^5.5.1",
+    "eslint-plugin-security": "^3.0.1"
   },
   "engines": {
     "node": ">=22"

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const tseslint = require('@typescript-eslint/eslint-plugin');
 const tsParser = require('@typescript-eslint/parser');
 const prettierPlugin = require('eslint-plugin-prettier');
 const jestPlugin = require('eslint-plugin-jest');
+const securityPlugin = require('eslint-plugin-security');
 
 /** @type {import('@eslint/eslintrc').FlatConfig[]} */
 module.exports = [
@@ -16,12 +17,14 @@ module.exports = [
       '@typescript-eslint': tseslint,
       prettier: prettierPlugin,
       jest: jestPlugin,
+      security: securityPlugin,
     },
     rules: {
       // use flat config recommended rules from @typescript-eslint
       ...tseslint.configs['flat/eslint-recommended'].rules,
       ...tseslint.configs.recommended.rules,
       ...prettierPlugin.configs.recommended.rules,
+      ...securityPlugin.configs.recommended.rules,
       'prettier/prettier': 'error',
     },
   },

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -7,19 +7,25 @@ describe('@dendavidov/eslint-config (flat config)', () => {
     expect(flatConfig.length).toBeGreaterThan(0);
   });
 
-  it('should include TypeScript, Prettier, and Jest plugins', () => {
+  it('should include TypeScript, Prettier, Jest, and Security plugins', () => {
     const main = flatConfig[0];
     expect(main.plugins).toHaveProperty('@typescript-eslint');
     expect(main.plugins).toHaveProperty('prettier');
     expect(main.plugins).toHaveProperty('jest');
+    expect(main.plugins).toHaveProperty('security');
   });
 
-  it('should apply Prettier and TypeScript recommended rules', () => {
+  it('should apply Prettier, TypeScript, and Security recommended rules', () => {
     const main = flatConfig[0];
     expect(main.rules).toHaveProperty('prettier/prettier', 'error');
     const ruleKeys = Object.keys(main.rules);
     expect(ruleKeys).toEqual(
-      expect.arrayContaining(['@typescript-eslint/ban-ts-comment', 'prettier/prettier', 'no-var']),
+      expect.arrayContaining([
+        '@typescript-eslint/ban-ts-comment',
+        'prettier/prettier',
+        'no-var',
+        'security/detect-bidi-characters',
+      ]),
     );
   });
 


### PR DESCRIPTION
## Summary
- include `eslint-plugin-security` dependency
- enable security plugin and rules in the base config
- update tests for the security plugin
- document security rules in README

## Testing
- `npm ci --ignore-scripts`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687969c24d788332aff12bdcdb9e39b1