### PR TITLE
Fix Jest globals in test config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Opinionated ESLint flat config for TypeScript-based Node.js projects.
 - **ESLint 9+ flat config**
 - **Node.js 22.x LTS or higher required**
 - **TypeScript, Prettier, Jest, and Security rules out of the box**
+- **Jest globals automatically available in test files**
 
 ## Installation
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,9 @@ module.exports = [
   },
   {
     files: ['**/__tests__/**/*', '**/*.{spec,test}.*'],
+    languageOptions: {
+      globals: { ...jestPlugin.environments.globals.globals },
+    },
     plugins: {
       jest: jestPlugin,
     },

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -35,6 +35,7 @@ describe('@dendavidov/eslint-config (flat config)', () => {
     );
     expect(testConfig).toBeDefined();
     expect(testConfig.plugins).toHaveProperty('jest');
+    expect(testConfig.languageOptions.globals).toHaveProperty('describe');
     expect(testConfig.rules).toHaveProperty('jest/no-conditional-expect');
     expect(testConfig.files).toEqual(
       expect.arrayContaining(['**/__tests__/**/*', '**/*.{spec,test}.*']),


### PR DESCRIPTION
## Summary
- ensure Jest globals are available in the test configuration
- assert Jest globals in tests
- mention Jest globals in README

## Testing
- `npm test`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_6879813c765c8332bfda3e6f170bc3a7